### PR TITLE
Fix permissions issues on geneated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To use the included generator execute the below command in shell and provide you
 
 ##### With Docker:
 ```sh
-> docker run --rm -it -v $PWD:/generated sudokar/generator-tf-module
+> docker run --rm -it -v $(pwd):/generated -e myuid="$(id -u):$(id -g)" sudokar/generator-tf-module
 ```
 ##### With NodeJs:
 ```sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,22 +14,27 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.version=$VERSION \
     org.label-schema.schema-version="1.0"
 
-RUN apk update && apk upgrade && \
-    apk add --no-cache bash git openssh curl && \
-    echo -n "Node: " && node -v && echo -n "npm: " && npm -v && \
-    npm install --global --silent yo && \
-    adduser -D -u 501 yeoman && \
-    echo "yeoman ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN apk update \
+    && apk add --no-cache bash git openssh curl sudo \
+    && echo "Node: $(node -v)" \
+    && echo "npm: $(npm -v)" \
+    && npm install --global --silent yo \
+    && adduser -D yeoman \
+    && echo "yeoman ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+    && echo "Set disable_coredump false" >> /etc/sudo.conf
+
+COPY entrypoint.sh /
 
 ENV HOME /home/yeoman
 
 RUN mkdir /generated && chown yeoman:yeoman /generated
 WORKDIR /generated
 
-RUN npm install --global --silent generator-tf-module && \
-    mkdir -p /home/yeoman/.config/configstore && \
-    chmod g+rwx /home/yeoman /home/yeoman/.config /home/yeoman/.config/configstore
+RUN npm install --global --silent generator-tf-module \
+    && mkdir -p /home/yeoman/.config/configstore \
+    && chown -R yeoman . \
+    && chmod g+rwx /home/yeoman /home/yeoman/.config /home/yeoman/.config/configstore
 
 USER yeoman
 
-CMD ["yo", "tf-module", "--no-insight"]
+CMD [ "/bin/sh", "/entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+yo tf-module --no-insight
+
+if [ ! "$myuid" = "" ] ; then
+  sudo chown -R "$myuid" .
+fi
+


### PR DESCRIPTION
This commit / PR fixes points raised in issue #9  about file permissions.

1. sudo wasn't in the list of packages to install; this adds it

2. `apk upgrade` anti-pattern removed

3. ownership / permissions of `/generated/` are fixed after node is
   installed

4. multi-line messages about node and npm versions was cleaned up

5. multi-line commands cleaned up (it's often stylstically preferable to
   put the '&&' and '||' conditions in the start of lines where it's
   more natural for the eye to scan)

6. execution of the `yo` command was moved inside of a script,
   `/entrypoint.sh`

7. after running the `yo` command in the entrypoint, if the variable
   `myuid` is non-empty, this will set the ownership (via `chown`) of
   the generated files

8. `README.md` was updated to dynamically capture and pass the user's
   UID and GID in the `myuid` environment variable (see aformentioned)

9. `README.md` also updated to dynamically capture the current working
   directory using the `pwd` command