### PR TITLE
Allow user to specify module source

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -28,6 +28,11 @@ module.exports = class extends Generator {
         message: 'Enter author name : ',
       },
       {
+        type: 'input',
+        name: 'source',
+        message: 'Enter the location of the module (for the "source" parameter) : ',
+      },
+      {
         type: 'list',
         name: 'tfVersion',
         message: 'Choose terraform version',
@@ -124,7 +129,8 @@ module.exports = class extends Generator {
         name: this.answers.name,
         description: this.answers.description,
         author: this.answers.author,
-        testFramework: this.answers.testFramework
+        testFramework: this.answers.testFramework,
+        source: this.answers.source,
       }
     );
   }

--- a/generators/app/templates/_README.md
+++ b/generators/app/templates/_README.md
@@ -10,7 +10,7 @@
 
 ```hcl
 module "<%= name %>" {
-  source = "git::ssh://"
+  source = "<%= source %>"
 }
 ```
 


### PR DESCRIPTION
**Note**: my Node is awful; what I've provided may not be great and should definitely be reviewed by someone who knows more than I do.


As-written, the tool adds the following to the module's documentation:

```
module "<%= name %>" {
  source = "git::ssh://"
}
```

This commit adds a prompt to the generator to request the value for
that `source` parameter.

TODO: consider pulling (i.e., `git remote -v`) and passing it to
the generator for use as a default value.